### PR TITLE
Handle 0 batteries on darwin.

### DIFF
--- a/battery_darwin.go
+++ b/battery_darwin.go
@@ -45,6 +45,11 @@ func readBatteries() ([]*battery, error) {
 		return nil, err
 	}
 
+	if len(out) == 0 {
+		// No batteries.
+		return nil, nil
+	}
+
 	var data []*battery
 	if _, err = plist.Unmarshal(out, &data); err != nil {
 		return nil, err


### PR DESCRIPTION
This allows `GetAll()` to successfully return when there are no batteries on a OS X system (e.g., a desktop computer).

Previously, it would return an error unmarshaling the property list, since there wasn't one.