### PR TITLE
Fix plist import

### DIFF
--- a/battery_darwin.go
+++ b/battery_darwin.go
@@ -25,7 +25,7 @@ import (
 	"math"
 	"os/exec"
 
-	plist "github.com/DHowett/go-plist"
+	plist "howett.net/plist"
 )
 
 type battery struct {

--- a/battery_netbsd.go
+++ b/battery_netbsd.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"unsafe"
 
-	plist "github.com/DHowett/go-plist"
+	plist "howett.net/plist"
 
 	"golang.org/x/sys/unix"
 )


### PR DESCRIPTION
The canonical import path for plist differs from the github path. This causes issues for those using Go modules: https://github.com/DHowett/go-plist/issues/40.