### PR TITLE
Battery not recognized on OpenBSD

### DIFF
--- a/battery_openbsd.go
+++ b/battery_openbsd.go
@@ -33,7 +33,7 @@ import (
 
 var errValueNotFound = fmt.Errorf("Value not found")
 
-var sensorW = [4]int32{
+var sensorW = [4]int{
 	2,  // SENSOR_VOLTS_DC (uV)
 	5,  // SENSOR_WATTS (uW)
 	7,  // SENSOR_WATTHOUR (uWh)
@@ -46,13 +46,13 @@ const (
 )
 
 type sensordev struct {
-	num           int32
+	num           int
 	xname         [16]byte
-	maxnumt       [21]int32
-	sensors_count int32
+	maxnumt       [21]int
+	sensors_count int
 }
 
-type sensorStatus int32
+type sensorStatus int
 
 const (
 	unspecified sensorStatus = iota
@@ -68,8 +68,8 @@ type sensor struct {
 	value  int64
 	typ    [4]byte // enum sensor_type
 	status sensorStatus
-	numt   int32
-	flags  int32
+	numt   int
+	flags  int
 }
 
 type interValue struct {
@@ -78,7 +78,7 @@ type interValue struct {
 	e *error
 }
 
-func sysctl(mib []int32, out unsafe.Pointer, n uintptr) syscall.Errno {
+func sysctl(mib []int, out unsafe.Pointer, n uintptr) syscall.Errno {
 	_, _, e := unix.Syscall6(
 		unix.SYS___SYSCTL,
 		uintptr(unsafe.Pointer(&mib[0])),
@@ -99,10 +99,9 @@ func readValue(s sensor, div float64) (float64, error) {
 	return float64(s.value) / div, nil
 }
 
-func readValues(mib []int32, c int32, values map[string]*interValue) {
+func readValues(mib []int, c int, values map[string]*interValue) {
 	var s sensor
-	var i int32
-	for i = 0; i < c; i++ {
+	for i := 0; i < c; i++ {
 		mib[4] = i
 
 		if err := sysctl(mib, unsafe.Pointer(&s), unsafe.Sizeof(s)); err != 0 {
@@ -147,11 +146,10 @@ func readValues(mib []int32, c int32, values map[string]*interValue) {
 }
 
 func sensordevIter(cb func(sd sensordev, i int, err error) bool) {
-	mib := []int32{6, 11, 0}
+	mib := []int{6, 11, 0}
 	var sd sensordev
 	var idx int
-	var i int32
-	for i = 0; ; i++ {
+	for i := 0; ; i++ {
 		mib[2] = i
 
 		e := sysctl(mib, unsafe.Pointer(&sd), unsafe.Sizeof(sd))
@@ -189,7 +187,7 @@ func getBattery(sd sensordev) (*Battery, error) {
 		DesignVoltage: errValueNotFound,
 	}
 
-	mib := []int32{6, 11, sd.num, 0, 0}
+	mib := []int{6, 11, sd.num, 0, 0}
 	for _, w := range sensorW {
 		mib[3] = w
 


### PR DESCRIPTION
Hi,

I was porting `gotop` to OpenBSD when I noticed that this library doesn't recognize the battery on my system (OpenBSD-CURRENT). Using some high level debugging techniques (a `fmt.Printf` before the return in `sysctl`) I've found that `unix.Syscall6` was returning `errno` 12 ("cannot allocate memory"). Referring to the [manpage sysctl(2)](https://man.openbsd.org/man2/sysctl.2#ENOMEM) `ENOMEM` is returned when the memory pointed by `oldlenp` (in this case, a pointer to a struct sensor) is too short.

Looking at the source code I see a bunch of `int32` while the definition of the [struct `sensor`](https://github.com/openbsd/src/blob/master/sys/sys/sensors.h#L110) use `int` (except for `type` which is int64). I've changed it and now the size of the struct is large enough.

Unfortunately, this doesn't fix the issue. Right now, `sensordevIter` will loop forever on my amd64: `unix.Syscall6` returns (always) `ENOTDIR`, which means that [«the name array specifies an intermediate rather than terminal name»](https://man.openbsd.org/man2/sysctl.2#ENOTDIR).

For the record, I tried the changes on an old i386 (with no batteries) with OpenBSD 6.3 and `sensordevIter` terminates.

Right now I don't have time to investigate this further. I'd like to know if you have any suggestions or ideas. In any case, during the weekend or the next week I should find the time to finish this pr.

Edit: grammar and clarifications