### PR TITLE
Add NotCharging state

### DIFF
--- a/battery.go
+++ b/battery.go
@@ -51,6 +51,7 @@ const (
 	Full
 	Charging
 	Discharging
+	NotCharging
 )
 
 var states = [...]string{
@@ -59,6 +60,7 @@ var states = [...]string{
 	Full:        "Full",
 	Charging:    "Charging",
 	Discharging: "Discharging",
+	NotCharging: "Not Charging",
 }
 
 func (s State) String() string {

--- a/battery_test.go
+++ b/battery_test.go
@@ -35,6 +35,7 @@ func TestNewState(t *testing.T) {
 	}{
 		{"Charging", Charging, nil},
 		{"charging", Charging, nil},
+		{"Not Charging", NotCharging, nil},
 		{"strange", Unknown, fmt.Errorf("Invalid state `strange`")},
 	}
 


### PR DESCRIPTION
Apparently my notebook reports the `Not Charging` status as well, this PR adds the status so that the tool won't return an error when this status is seen.

```
dvitali@denvit-ws1:power_supply/BAT0 $ pwd
/sys/class/power_supply/BAT0
dvitali@denvit-ws1:power_supply/BAT0 $ cat status
Not Charging
```