### PR TITLE
Use Apple Raw capacities for M1 Mac

### DIFF
--- a/battery_darwin.go
+++ b/battery_darwin.go
@@ -30,8 +30,8 @@ import (
 
 type battery struct {
 	Voltage           int
-	CurrentCapacity   int
-	MaxCapacity       int
+	CurrentCapacity   int `plist:"AppleRawCurrentCapacity"`
+	MaxCapacity       int `plist:"AppleRawMaxCapacity"`
 	DesignCapacity    int
 	Amperage          int64
 	FullyCharged      bool


### PR DESCRIPTION
Are there anyone facing this issue with M1 Mac? CurrentCapacity and MaxCapacity are reported in percentage. Adding AppleRaw prefix yields the correct capacity in mAh on both older and newer Macs.