### PR TITLE
Adds a simplified output mode

### DIFF
--- a/cmd/battery/main.go
+++ b/cmd/battery/main.go
@@ -22,6 +22,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"time"
@@ -30,6 +31,25 @@ import (
 )
 
 func printBattery(idx int, bat *battery.Battery) {
+	simple := flag.Bool("s", false, "Simple format")
+	flag.Parse()
+	if *simple {
+		var icon int
+		switch bat.State {
+		case battery.Full:
+			icon = 0x1F50B
+		case battery.Empty:
+			icon = 0x1FAAB
+		case battery.Charging:
+			icon = 0x1F50C
+		case battery.Discharging:
+			icon = 0x1F50B
+		default:
+			icon = 0x2047
+		}
+		fmt.Printf("%c %d%%", icon, int((bat.Current/bat.Full*100)+0.5))
+		return
+	}
 	fmt.Printf(
 		"BAT%d: %s, %.2f%%",
 		idx,


### PR DESCRIPTION
I use this in my lock screen script to generate the battery status on my laptop. The original text was TMI (for a lock screen) and required a fair bit of processing to extract only the information I wanted.

This change adds a trivial flag `-s` which, when provided, prints out only the charge state (using unicode emoji characters) and the % charge.

```sh
$ battery
BAT0: Discharging, 47.25%, 2h33m45.7848s remaining [Voltage: 7.53V (design: 7.60V)]
$ battery -s   # Discharging
🔋 47%
$ battery -s   # Empty
🪫 0%
$ battery -s   # Fully
🔋 100%
$ battery -s   # Charging
🔌 49%
```