### PR TITLE
Errors() +performance : using strings.Builder instead of string concatenation

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -21,7 +21,10 @@
 
 package battery
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // ErrNotFound variable represents battery not found error.
 //
@@ -128,6 +131,23 @@ func (e Errors) Error() string {
 		s = s[:len(s)-1]
 	}
 	return s + "]"
+}
+
+func (e Errors) ErrorBuilder() string {
+	var s strings.Builder
+	s.WriteString("[")
+	for idx, err := range e {
+		if err != nil {
+			if idx == len(e)-1 {
+				s.Write([]byte(err.Error()))
+			} else {
+				s.WriteString(err.Error())
+				s.WriteString(" ")
+			}
+		}
+	}
+	s.WriteString("]")
+	return s.String()
 }
 
 func wrapError(err error) error {

--- a/errors.go
+++ b/errors.go
@@ -121,29 +121,14 @@ func (p ErrPartial) noNil() bool {
 type Errors []error
 
 func (e Errors) Error() string {
-	s := "["
-	for _, err := range e {
-		if err != nil {
-			s += err.Error() + " "
-		}
-	}
-	if len(s) > 1 {
-		s = s[:len(s)-1]
-	}
-	return s + "]"
-}
-
-func (e Errors) ErrorBuilder() string {
 	var s strings.Builder
 	s.WriteString("[")
 	for idx, err := range e {
 		if err != nil {
-			if idx == len(e)-1 {
-				s.Write([]byte(err.Error()))
-			} else {
-				s.WriteString(err.Error())
+			if idx >= 1 {
 				s.WriteString(" ")
 			}
+			s.WriteString(err.Error())
 		}
 	}
 	s.WriteString("]")

--- a/errors_test.go
+++ b/errors_test.go
@@ -66,6 +66,7 @@ func TestErrors(t *testing.T) {
 		{Errors{ErrFatal{errors.New("t1")}}, "[Could not retrieve battery info: `t1`]"},
 		{Errors{ErrPartial{Full: errors.New("t2")}, ErrFatal{errors.New("t3")}}, "[{Full:t2} Could not retrieve battery info: `t3`]"},
 		{Errors{ErrPartial{Full: errors.New("t4")}, ErrPartial{Current: errors.New("t5")}}, "[{Full:t4} {Current:t5}]"},
+		{Errors{ErrFatal{errors.New("testing error")}, nil}, "[Could not retrieve battery info: `testing error`]"},
 	}
 
 	for i, c := range cases {
@@ -82,14 +83,6 @@ func BenchmarkErrors_Error(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = e.Error()
-	}
-}
-
-func BenchmarkErrors_ErrorBuilder(b *testing.B) {
-	e := getErrors()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = e.ErrorBuilder()
 	}
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -79,6 +79,7 @@ func TestErrors(t *testing.T) {
 
 func BenchmarkErrors_Error(b *testing.B) {
 	e := getErrors()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = e.Error()
 	}
@@ -86,6 +87,7 @@ func BenchmarkErrors_Error(b *testing.B) {
 
 func BenchmarkErrors_ErrorBuilder(b *testing.B) {
 	e := getErrors()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = e.ErrorBuilder()
 	}

--- a/errors_test.go
+++ b/errors_test.go
@@ -76,3 +76,27 @@ func TestErrors(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkErrors_Error(b *testing.B) {
+	e := getErrors()
+	for i := 0; i < b.N; i++ {
+		_ = e.Error()
+	}
+}
+
+func BenchmarkErrors_ErrorBuilder(b *testing.B) {
+	e := getErrors()
+	for i := 0; i < b.N; i++ {
+		_ = e.ErrorBuilder()
+	}
+}
+
+func getErrors() Errors {
+	return Errors([]error{
+		errors.New("1"),
+		errors.New("2"),
+		errors.New("3"),
+		errors.New("4"),
+		errors.New("5"),
+	})
+}


### PR DESCRIPTION
Proposing to use `strings.Builder` in place of `string concatenation`, in `battery.Error()` - following are the results -
```
╭─manish@console.local ~/workspace/battery  ‹master› 
╰─➤  go test -bench=. -benchtime 2s -count 1 -benchmem -cpu 4 -run notest
goos: darwin
goarch: arm64
pkg: github.com/distatus/battery
BenchmarkErrors_Error-4                 14642497               147.5 ns/op            64 B/op          6 allocs/op
BenchmarkErrors_ErrorBuilder-4          37910373                63.16 ns/op           24 B/op          2 allocs/op
PASS
ok      github.com/distatus/battery     4.896s
```